### PR TITLE
Replace for..in with for statement

### DIFF
--- a/src/stringformat.js
+++ b/src/stringformat.js
@@ -780,7 +780,7 @@ var sffjs = (function() {
 
     // If a format method has not already been defined on the following objects, set __Format as format.
     var formattables = [ Date.prototype, _Number.prototype, _String ];
-    for (var i in formattables) {
+    for (var i = 0, length = formattables.length; i < length; i++) {
         formattables[i].format = formattables[i].format || formattables[i].__Format;
     }
     


### PR DESCRIPTION
I had a problem with for..in statement. After upgrading aurelia framework to newest version, our app stops working with console error. It looks like Aurelia adds custom property to array prototype (__au_patched__: 1). You iterate array of formattables with for..in statement which causes iterates also through aurelia custom property and app fails.